### PR TITLE
[#3] 샵 별로 직원이 등록됩니다

### DIFF
--- a/src/main/java/com/herren/project/employees/domain/Employee.java
+++ b/src/main/java/com/herren/project/employees/domain/Employee.java
@@ -28,12 +28,11 @@ public class Employee {
     protected Employee() {
     }
 
-    public Employee(String name, String phoneNumber, String kakaoId, EmployeeStatus employeeStatus, Shop shop) {
+    public Employee(String name, String phoneNumber, String kakaoId, EmployeeStatus employeeStatus) {
         this.name = name;
         this.phoneNumber = phoneNumber;
         this.kakaoId = kakaoId;
         this.employeeStatus = employeeStatus;
-        this.shop = shop;
     }
 
     public String getName() {
@@ -56,13 +55,39 @@ public class Employee {
         return shop;
     }
 
+    public void joinShop(Shop shop) {
+        validateJoinShopCheck();
+        this.shop = shop;
+        this.shop.updateStaff(this);
+    }
+
+    public void resignShop() {
+        if (this.shop != null) {
+            this.shop.deleteStaffInfo(this);
+            this.shop = null;
+        }
+    }
+
     public void changeStaffStatus(EmployeeStatus employeeStatus) {
         this.employeeStatus = employeeStatus;
         if (this.employeeStatus == EmployeeStatus.DELETE) {
             this.name = null;
             this.phoneNumber = null;
             this.kakaoId = null;
-            this.shop.deleteStaffInfo(this);
+            resignShop();
         }
+    }
+
+    private void validateJoinShopCheck() {
+        if (this.shop != null) {
+            throw new IllegalArgumentException("이미 근무중인 샵이 있습니다.");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Employee{" +
+                "name='" + name + '\'' +
+                '}';
     }
 }

--- a/src/main/java/com/herren/project/employees/domain/Staff.java
+++ b/src/main/java/com/herren/project/employees/domain/Staff.java
@@ -9,13 +9,10 @@ import javax.persistence.OneToMany;
 @Embeddable
 public class Staff {
     @OneToMany(mappedBy = "shop")
-    private List<Employee> staff = new ArrayList<>();
+    private final List<Employee> staff;
 
-    protected Staff() {
-    }
-
-    public Staff(List<Employee> staff) {
-        this.staff = new ArrayList<>(staff);
+    public Staff() {
+        this.staff = new ArrayList<>();
     }
 
     public List<Employee> getStaff() {
@@ -23,10 +20,17 @@ public class Staff {
     }
 
     public void addEmployee(Employee employee) {
+        validateStaffCheck(employee);
         this.staff.add(employee);
     }
 
-    public void removeEmployee(Employee employee) {
+    public void deleteEmployee(Employee employee) {
         this.staff.remove(employee);
+    }
+
+    private void validateStaffCheck(Employee employee) {
+        if (this.staff.contains(employee)) {
+            throw new IllegalArgumentException("이미 해당 샵에 존재하는 직원입니다.");
+        }
     }
 }

--- a/src/main/java/com/herren/project/shop/domain/Shop.java
+++ b/src/main/java/com/herren/project/shop/domain/Shop.java
@@ -2,7 +2,6 @@ package com.herren.project.shop.domain;
 
 import com.herren.project.employees.domain.Employee;
 import com.herren.project.employees.domain.Staff;
-import java.util.ArrayList;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -38,7 +37,7 @@ public class Shop {
         this.phoneNumber = phoneNumber;
         this.kakaoId = kakaoId;
         this.shopStatus = shopStatus;
-        this.staff = new Staff(new ArrayList<>());
+        this.staff = new Staff();
     }
 
     public String getShopName() {
@@ -79,6 +78,6 @@ public class Shop {
     }
 
     public void deleteStaffInfo(Employee employee) {
-        this.staff.removeEmployee(employee);
+        this.staff.deleteEmployee(employee);
     }
 }

--- a/src/test/java/com/herren/project/employees/domain/EmployeeTest.java
+++ b/src/test/java/com/herren/project/employees/domain/EmployeeTest.java
@@ -1,6 +1,7 @@
 package com.herren.project.employees.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.herren.project.shop.domain.Shop;
@@ -15,8 +16,7 @@ class EmployeeTest {
     @ParameterizedTest(name = "직원의 재직 상태가 {0}으로 변경된다")
     @EnumSource(value = EmployeeStatus.class, names = {"NORMAL", "DELETE"})
     void changeStaffStatus(EmployeeStatus expected) {
-        Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
-        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL, shop);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
 
         employee.changeStaffStatus(expected);
 
@@ -26,8 +26,7 @@ class EmployeeTest {
     @Test
     @DisplayName("직원의 상태가 삭제로 변경되면 해당 직원의 이름, 연락처, 카카오톡 아이디를 삭제한다")
     void changeStaffStatusThenChangeStaffInfo() {
-        Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
-        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL, shop);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
 
         employee.changeStaffStatus(EmployeeStatus.DELETE);
 
@@ -39,11 +38,34 @@ class EmployeeTest {
     }
 
     @Test
+    @DisplayName("직원이 샵 정보를 등록하면 직원의 샵 정보가 등록된다")
+    void joinShop() {
+        Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
+
+        employee.joinShop(shop);
+
+        assertThat(employee.getShop()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 근무중인 샵이 있는 경우 샵 정보를 추가로 등록할 수 없다")
+    void duplicateJoinShop() {
+        Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
+        employee.joinShop(shop);
+
+        assertThatIllegalArgumentException().isThrownBy(
+                () -> employee.joinShop(shop)
+        ).withMessageContaining("이미 근무중인 샵이 있습니다.");
+    }
+
+    @Test
     @DisplayName("직원의 상태가 삭제로 변경되면 해당 직원이 속해있던 샵 정보에서 직원 정보를 삭제한다")
     void changeStaffStatusThenDeleteStaffInfoToShop() {
         Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
-        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL, shop);
-        shop.updateStaff(employee);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
+        employee.joinShop(shop);
         int actual = shop.getStaff().getStaff().size();
 
         employee.changeStaffStatus(EmployeeStatus.DELETE);

--- a/src/test/java/com/herren/project/shop/domain/ShopTest.java
+++ b/src/test/java/com/herren/project/shop/domain/ShopTest.java
@@ -3,6 +3,8 @@ package com.herren.project.shop.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.herren.project.employees.domain.Employee;
+import com.herren.project.employees.domain.EmployeeStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,5 +35,28 @@ class ShopTest {
                 () -> assertThat(shop.getPhoneNumber()).isNull(),
                 () -> assertThat(shop.getKakaoId()).isNull()
         );
+    }
+
+    @Test
+    @DisplayName("직원이 샵 정보를 등록하면 샵에 직원 정보가 등록된다")
+    void joinShop() {
+        Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
+
+        employee.joinShop(shop);
+
+        assertThat(shop.getStaff()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("샵에 등록되어 있던 직원이 샵 정보를 삭제하면 샵의 직원 정보가 삭제된다")
+    void resignShop() {
+        Shop shop = new Shop("헤어샵", "12345", "010-1234-1234", "kakaoid", ShopStatus.WAITING);
+        Employee employee = new Employee("직원A", "010-1234-1234", "kakao@kakao.com", EmployeeStatus.NORMAL);
+        employee.joinShop(shop);
+
+        employee.resignShop();
+
+        assertThat(shop.getStaff().getStaff()).isEmpty();
     }
 }


### PR DESCRIPTION
1. 샵은 최초 생성이후 직원을 통해 샵의 직원 정보를 업데이트 합니다
  - 직원 -> 샵 정보 업데이트 -> 샵의 직원 정보 업데이트
2. 한명의 직원은 하나의 샵에만 등록되어야 합니다
3. 직원이 샵을 그만두는 경우 샵의 직원 정보를 삭제합니다
4. 샵이 영업을 종료하는 경우 직원의 샵 정보 변경은 서비스단에서 처리할 예정입니다